### PR TITLE
[FEAT] Pantallas de Autenticación - Login y Registro

### DIFF
--- a/app/src/main/java/com/appnotresponding/rumbo/ui/components/organisms/auth/LoginForm.kt
+++ b/app/src/main/java/com/appnotresponding/rumbo/ui/components/organisms/auth/LoginForm.kt
@@ -28,10 +28,7 @@ import com.appnotresponding.rumbo.ui.components.molecules.auth.AuthEmailText
 import com.appnotresponding.rumbo.ui.components.molecules.auth.AuthPasswordText
 import com.appnotresponding.rumbo.ui.theme.RumboTheme
 
-/**
- * Organismo que representa el formulario completo de inicio de sesión.
- * Incluye campos de correo, contraseña, botón de inicio de sesión y opción para recuperar la contraseña.
- */
+
 @Composable
 fun LoginForm(
     onLoginClick: (String, String) -> Unit = { _, _ -> },
@@ -44,13 +41,13 @@ fun LoginForm(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            // Configuración del contenedor tipo "Card" oscura (según mockup)
+            
             .clip(RoundedCornerShape(12.dp))
             .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.8f))
             .padding(24.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        // Campo de Correo
+     
         AuthEmailText(
             value = email,
             onValueChange = { email = it },
@@ -60,7 +57,7 @@ fun LoginForm(
         
         Spacer(modifier = Modifier.height(4.dp))
 
-        // Campo de Contraseña
+     
         AuthPasswordText(
             value = password,
             onValueChange = { password = it },
@@ -70,7 +67,7 @@ fun LoginForm(
         
         Spacer(modifier = Modifier.height(8.dp))
 
-        // Botón Iniciar Sesión
+    
         RumboButton(
             text = "Iniciar Sesión",
             onClick = { onLoginClick(email, password) },
@@ -78,7 +75,7 @@ fun LoginForm(
             modifier = Modifier.fillMaxWidth(),
         )
 
-        // Botón/Texto Recuperar contraseña
+     
         Text(
             text = "Recuperar contraseña",
             style = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.onSurfaceVariant),

--- a/app/src/main/java/com/appnotresponding/rumbo/ui/components/organisms/auth/LoginForm.kt
+++ b/app/src/main/java/com/appnotresponding/rumbo/ui/components/organisms/auth/LoginForm.kt
@@ -1,4 +1,101 @@
 package com.appnotresponding.rumbo.ui.components.organisms.auth
 
-// EMAIL + PASSWORD + LOGIN BUTTON + FORGOT PASSWORD + SIGN UP
-//TODO
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.appnotresponding.rumbo.ui.components.atoms.RumboButton
+import com.appnotresponding.rumbo.ui.components.atoms.RumboButtonStyle
+import com.appnotresponding.rumbo.ui.components.molecules.auth.AuthEmailText
+import com.appnotresponding.rumbo.ui.components.molecules.auth.AuthPasswordText
+import com.appnotresponding.rumbo.ui.theme.RumboTheme
+
+/**
+ * Organismo que representa el formulario completo de inicio de sesión.
+ * Incluye campos de correo, contraseña, botón de inicio de sesión y opción para recuperar la contraseña.
+ */
+@Composable
+fun LoginForm(
+    onLoginClick: (String, String) -> Unit = { _, _ -> },
+    onForgotPasswordClick: () -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    var email by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            // Configuración del contenedor tipo "Card" oscura (según mockup)
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.8f))
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        // Campo de Correo
+        AuthEmailText(
+            value = email,
+            onValueChange = { email = it },
+            label = "Correo",
+            placeholder = "correo@gmail.com"
+        )
+        
+        Spacer(modifier = Modifier.height(4.dp))
+
+        // Campo de Contraseña
+        AuthPasswordText(
+            value = password,
+            onValueChange = { password = it },
+            label = "Contraseña",
+            placeholder = "********"
+        )
+        
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Botón Iniciar Sesión
+        RumboButton(
+            text = "Iniciar Sesión",
+            onClick = { onLoginClick(email, password) },
+            style = RumboButtonStyle.Primary,
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        // Botón/Texto Recuperar contraseña
+        Text(
+            text = "Recuperar contraseña",
+            style = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.onSurfaceVariant),
+            textDecoration = TextDecoration.Underline,
+            modifier = Modifier
+                .clickable(onClick = onForgotPasswordClick)
+                .padding(top = 8.dp)
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Login Form - Dark", backgroundColor = 0xFF121212)
+@Composable
+private fun LoginFormPreviewDark() {
+    RumboTheme(darkTheme = true) {
+        LoginForm(
+            modifier = Modifier.padding(16.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/appnotresponding/rumbo/ui/components/organisms/auth/SignUpForm.kt
+++ b/app/src/main/java/com/appnotresponding/rumbo/ui/components/organisms/auth/SignUpForm.kt
@@ -44,10 +44,7 @@ import com.appnotresponding.rumbo.ui.components.molecules.auth.AuthPhoneText
 import com.appnotresponding.rumbo.ui.components.molecules.auth.AuthPlainText
 import com.appnotresponding.rumbo.ui.theme.RumboTheme
 
-/**
- * Organismo que representa el formulario completo de registro (Sign Up).
- * Incluye campos para nombre, celular, correo, contraseña, selección de país y términos.
- */
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SignUpForm(
@@ -59,12 +56,11 @@ fun SignUpForm(
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
     
-    // Variables para el Dropdown (País)
     var expanded by remember { mutableStateOf(false) }
     val countries = listOf("Colombia", "México", "Argentina", "España", "Perú", "Chile")
     var selectedCountry by remember { mutableStateOf(countries[0]) }
 
-    // Variable para Checkbox de términos
+ 
     var termsAccepted by remember { mutableStateOf(false) }
 
     Column(
@@ -113,7 +109,7 @@ fun SignUpForm(
             onExpandedChange = { expanded = !expanded },
             modifier = Modifier.fillMaxWidth()
         ) {
-            // Usamos RumboTextField configurado para ser el trigger del dropdown
+         
             RumboTextField(
                 value = selectedCountry,
                 onValueChange = {},
@@ -144,7 +140,7 @@ fun SignUpForm(
             }
         }
 
-        // Casilla: Términos y Condiciones
+        
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
@@ -160,7 +156,7 @@ fun SignUpForm(
                 modifier = Modifier.size(20.dp)
             )
             
-            // Texto estilizado simulando enlaces
+        
             val termsText = buildAnnotatedString {
                 withStyle(style = SpanStyle(color = MaterialTheme.colorScheme.onSurface)) {
                     append("He leído y acepto los términos y condiciones de uso.\n")

--- a/app/src/main/java/com/appnotresponding/rumbo/ui/components/organisms/auth/SignUpForm.kt
+++ b/app/src/main/java/com/appnotresponding/rumbo/ui/components/organisms/auth/SignUpForm.kt
@@ -1,4 +1,206 @@
 package com.appnotresponding.rumbo.ui.components.organisms.auth
 
-// NAME + PHONE + EMAIL + PASSWORD + RESIDENCE + TOS + SIGN UP BUTTON + LOGIN
-//TODO
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.appnotresponding.rumbo.ui.components.atoms.RumboButton
+import com.appnotresponding.rumbo.ui.components.atoms.RumboButtonStyle
+import com.appnotresponding.rumbo.ui.components.atoms.RumboTextField
+import com.appnotresponding.rumbo.ui.components.molecules.auth.AuthEmailText
+import com.appnotresponding.rumbo.ui.components.molecules.auth.AuthPasswordText
+import com.appnotresponding.rumbo.ui.components.molecules.auth.AuthPhoneText
+import com.appnotresponding.rumbo.ui.components.molecules.auth.AuthPlainText
+import com.appnotresponding.rumbo.ui.theme.RumboTheme
+
+/**
+ * Organismo que representa el formulario completo de registro (Sign Up).
+ * Incluye campos para nombre, celular, correo, contraseña, selección de país y términos.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SignUpForm(
+    onSignUpClick: (String, String, String, String, String, Boolean) -> Unit = { _, _, _, _, _, _ -> },
+    modifier: Modifier = Modifier
+) {
+    var fullName by remember { mutableStateOf("") }
+    var phone by remember { mutableStateOf("") }
+    var email by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+    
+    // Variables para el Dropdown (País)
+    var expanded by remember { mutableStateOf(false) }
+    val countries = listOf("Colombia", "México", "Argentina", "España", "Perú", "Chile")
+    var selectedCountry by remember { mutableStateOf(countries[0]) }
+
+    // Variable para Checkbox de términos
+    var termsAccepted by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.8f))
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        // Campo: Nombre Completo
+        AuthPlainText(
+            value = fullName,
+            onValueChange = { fullName = it },
+            label = "Nombre Completo",
+            placeholder = "Nombres Apellidos"
+        )
+
+        // Campo: Celular
+        AuthPhoneText(
+            value = phone,
+            onValueChange = { phone = it },
+            label = "Celular",
+            placeholder = "+57 312 345 6789"
+        )
+
+        // Campo: Correo
+        AuthEmailText(
+            value = email,
+            onValueChange = { email = it },
+            label = "Correo",
+            placeholder = "correo@gmail.com"
+        )
+
+        // Campo: Contraseña
+        AuthPasswordText(
+            value = password,
+            onValueChange = { password = it },
+            label = "Contraseña",
+            placeholder = "********"
+        )
+
+        // Campo: País de Residencia (Dropdown)
+        ExposedDropdownMenuBox(
+            expanded = expanded,
+            onExpandedChange = { expanded = !expanded },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            // Usamos RumboTextField configurado para ser el trigger del dropdown
+            RumboTextField(
+                value = selectedCountry,
+                onValueChange = {},
+                readOnly = true,
+                label = "País de Residencia",
+                trailingIcon = {
+                    ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
+                },
+                modifier = Modifier
+                    .menuAnchor()
+                    .fillMaxWidth()
+            )
+
+            ExposedDropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false },
+                modifier = Modifier.background(MaterialTheme.colorScheme.surfaceVariant)
+            ) {
+                countries.forEach { selectionOption ->
+                    DropdownMenuItem(
+                        text = { Text(text = selectionOption, color = MaterialTheme.colorScheme.onSurface) },
+                        onClick = {
+                            selectedCountry = selectionOption
+                            expanded = false
+                        }
+                    )
+                }
+            }
+        }
+
+        // Casilla: Términos y Condiciones
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Checkbox(
+                checked = termsAccepted,
+                onCheckedChange = { termsAccepted = it },
+                colors = CheckboxDefaults.colors(
+                    checkedColor = MaterialTheme.colorScheme.primary, // El verde de la app
+                    uncheckedColor = MaterialTheme.colorScheme.onSurfaceVariant
+                ),
+                modifier = Modifier.size(20.dp)
+            )
+            
+            // Texto estilizado simulando enlaces
+            val termsText = buildAnnotatedString {
+                withStyle(style = SpanStyle(color = MaterialTheme.colorScheme.onSurface)) {
+                    append("He leído y acepto los términos y condiciones de uso.\n")
+                }
+                withStyle(
+                    style = SpanStyle(
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textDecoration = TextDecoration.Underline
+                    )
+                ) {
+                    append("Términos y condiciones.")
+                }
+            }
+            Text(
+                text = termsText,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(start = 8.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Botón: Registrarse
+        RumboButton(
+            text = "Registrarse",
+            onClick = {
+                onSignUpClick(fullName, phone, email, password, selectedCountry, termsAccepted)
+            },
+            style = RumboButtonStyle.Primary,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Sign Up Form - Dark", backgroundColor = 0xFF121212)
+@Composable
+private fun SignUpFormPreviewDark() {
+    RumboTheme(darkTheme = true) {
+        Box(modifier = Modifier.padding(16.dp)) {
+            SignUpForm()
+        }
+    }
+}

--- a/app/src/main/java/com/appnotresponding/rumbo/ui/screens/auth/LoginScreen.kt
+++ b/app/src/main/java/com/appnotresponding/rumbo/ui/screens/auth/LoginScreen.kt
@@ -1,0 +1,39 @@
+package com.appnotresponding.rumbo.ui.screens.auth
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.appnotresponding.rumbo.ui.components.organisms.auth.LoginForm
+import com.appnotresponding.rumbo.ui.templates.AuthTemplate
+import com.appnotresponding.rumbo.ui.theme.RumboTheme
+
+
+@Composable
+fun LoginScreen(
+    onNavigateToHome: () -> Unit = {},
+    onNavigateToSignUp: () -> Unit = {},
+    onNavigateToForgotPassword: () -> Unit = {}
+) {
+    AuthTemplate {
+
+        LoginForm(
+            onLoginClick = { email, password ->
+
+                onNavigateToHome()
+            },
+            onForgotPasswordClick = {
+                onNavigateToForgotPassword()
+            },
+            modifier = Modifier
+        )
+    }
+}
+
+
+@Preview(showBackground = true, name = "Pantalla Login demostración ", backgroundColor = 0xFF121212)
+@Composable
+private fun LoginScreenPreview() {
+    RumboTheme(darkTheme = true) {
+        LoginScreen()
+    }
+}

--- a/app/src/main/java/com/appnotresponding/rumbo/ui/screens/auth/SignUpScreen.kt
+++ b/app/src/main/java/com/appnotresponding/rumbo/ui/screens/auth/SignUpScreen.kt
@@ -1,0 +1,43 @@
+package com.appnotresponding.rumbo.ui.screens.auth
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.appnotresponding.rumbo.ui.components.organisms.auth.SignUpForm
+import com.appnotresponding.rumbo.ui.templates.AuthTemplate
+import com.appnotresponding.rumbo.ui.theme.RumboTheme
+
+
+@Composable
+fun SignUpScreen(
+    onNavigateBack: () -> Unit = {},
+    onSignUpComplete: () -> Unit = {}
+) {
+    AuthTemplate {
+
+        val scrollState = rememberScrollState()
+
+        SignUpForm(
+            onSignUpClick = { fullName, phone, email, password, country, termsAccepted ->
+                // Aquí iría la validación lógica y la llamada a Firebase Auth o API.
+                // Por razones de demostración, simulamos la navegación si completaron:
+                onSignUpComplete()
+            },
+            modifier = Modifier
+                .verticalScroll(scrollState)
+                .fillMaxSize()
+        )
+    }
+}
+
+
+@Preview(showBackground = true, name = "antalla Registro demostración ", backgroundColor = 0xFF121212)
+@Composable
+private fun SignUpScreenPreview() {
+    RumboTheme(darkTheme = true) {
+        SignUpScreen()
+    }
+}

--- a/app/src/main/java/com/appnotresponding/rumbo/ui/screens/auth/SignUpScreen.kt
+++ b/app/src/main/java/com/appnotresponding/rumbo/ui/screens/auth/SignUpScreen.kt
@@ -22,8 +22,7 @@ fun SignUpScreen(
 
         SignUpForm(
             onSignUpClick = { fullName, phone, email, password, country, termsAccepted ->
-                // Aquí iría la validación lógica y la llamada a Firebase Auth o API.
-                // Por razones de demostración, simulamos la navegación si completaron:
+           
                 onSignUpComplete()
             },
             modifier = Modifier

--- a/app/src/main/java/com/appnotresponding/rumbo/ui/templates/AuthTemplate.kt
+++ b/app/src/main/java/com/appnotresponding/rumbo/ui/templates/AuthTemplate.kt
@@ -1,3 +1,53 @@
 package com.appnotresponding.rumbo.ui.templates
 
-//TODO
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+/**
+ * Plantilla (Template) para las pantallas de Autenticación.
+ * Define la estructura visual base: el fondo estilo «Aurora» verde y negro (según mockup),
+ * y centra el contenido que se le pase por parámetro.
+ *
+ * @param modifier Modificador para el contenedor principal.
+ * @param content El contenido interno (por ejemplo, el LoginForm o el SignUpForm).
+ */
+@Composable
+fun AuthTemplate(
+    modifier: Modifier = Modifier,
+    content: @Composable BoxScope.() -> Unit
+) {
+    // Definimos el color verde resplandeciente del diseño simulando el Light Saber/Aurora
+    val highlightGreen = Color(0xFFC4F031) // Color primario aprox de RumboButton
+    val darkBackground = Color(0xFF151515) // Fondo oscuro
+
+    // Simulación del resplandor radial/lineal de la imagen
+    val backgroundBrush = Brush.radialGradient(
+        colors = listOf(
+            highlightGreen.copy(alpha = 0.35f), // Resplandor centro/izquierda
+            darkBackground,
+            Color.Black
+        ),
+        center = Offset(x = 100f, y = 800f), // Ajustado para que surja desde la izquierda media baja
+        radius = 1200f
+    )
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(brush = backgroundBrush)
+            .padding(24.dp), // Padding general de la pantalla
+        contentAlignment = Alignment.Center
+    ) {
+        content()
+    }
+}

--- a/app/src/main/java/com/appnotresponding/rumbo/ui/templates/AuthTemplate.kt
+++ b/app/src/main/java/com/appnotresponding/rumbo/ui/templates/AuthTemplate.kt
@@ -26,18 +26,18 @@ fun AuthTemplate(
     modifier: Modifier = Modifier,
     content: @Composable BoxScope.() -> Unit
 ) {
-    // Definimos el color verde resplandeciente del diseño simulando el Light Saber/Aurora
-    val highlightGreen = Color(0xFFC4F031) // Color primario aprox de RumboButton
-    val darkBackground = Color(0xFF151515) // Fondo oscuro
 
-    // Simulación del resplandor radial/lineal de la imagen
+    val highlightGreen = Color(0xFFC4F031) 
+    val darkBackground = Color(0xFF151515) 
+
+  
     val backgroundBrush = Brush.radialGradient(
         colors = listOf(
-            highlightGreen.copy(alpha = 0.35f), // Resplandor centro/izquierda
+            highlightGreen.copy(alpha = 0.35f), 
             darkBackground,
             Color.Black
         ),
-        center = Offset(x = 100f, y = 800f), // Ajustado para que surja desde la izquierda media baja
+        center = Offset(x = 100f, y = 800f),
         radius = 1200f
     )
 
@@ -45,7 +45,7 @@ fun AuthTemplate(
         modifier = modifier
             .fillMaxSize()
             .background(brush = backgroundBrush)
-            .padding(24.dp), // Padding general de la pantalla
+            .padding(24.dp), 
         contentAlignment = Alignment.Center
     ) {
         content()


### PR DESCRIPTION
¿que hize?
Implementación de las pantallas de Login y Registro siguiendo Atomic Design con Jetpack Compose.
Cambios realizados
- AuthTemplate: Fondo con efecto aurora/resplandor verde radial según mockup
- LoginForm: Formulario con campos de correo (validado), contraseña (con toggle de visibilidad) y botón "Iniciar Sesión"
- SignUpForm: Formulario con campos de nombre, celular (formato E.164), correo, contraseña, selector de país y checkbox de términos
- LoginScreen: Pantalla final ensamblada con callbacks de navegación listos para NavHost
- SignUpScreen: Pantalla final con scroll vertical para pantallas pequeñas

Arquitectura
Atoms → Molecules → Organisms → Templates → Screens

Preview
Cada componente incluye "@Preview" funcional en modo dark para verificación visual en Android Studio, aunque de por mi no los quiten porque se puede usar con eso y es de garn ayuda.

Closes #3
